### PR TITLE
Expose coap options

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -2,7 +2,7 @@ use codec::CoapCodec;
 use Endpoint;
 use error::{Error, UrlError};
 use message::{Message, Code};
-use message::option::{Option, Options, UriPath, UriHost, UriQuery};
+use message::option::{Option, Options, UriPath, UriHost, UriQuery, Byteable};
 
 use std::borrow::Cow;
 use std::net::Ipv4Addr;

--- a/src/client.rs
+++ b/src/client.rs
@@ -126,6 +126,15 @@ impl Client {
         self
     }
 
+    pub fn set_option<T: Option + Byteable>(&mut self, option: T) {
+        self.msg.options.push(option);
+    }
+
+    pub fn with_option<T: Option + Byteable>(mut self, option: T) -> Self {
+        self.msg.options.push(option);
+        self
+    }
+
     pub fn send(self) -> IoFuture<Message> {
         let local_addr = "0.0.0.0:0".parse().unwrap();
 

--- a/src/message/option/mod.rs
+++ b/src/message/option/mod.rs
@@ -380,6 +380,6 @@ options![
     (35, ProxyUri, string, 1, 1034),
     (29, ProxyScheme, string, 1, 255),
     (60, Size1, uint, 0, 4),
+    (61, Token, string, 0, 32),
     (284, NoResponse, uint, 0, 1),
 ];
-

--- a/src/message/option/mod.rs
+++ b/src/message/option/mod.rs
@@ -383,3 +383,4 @@ options![
     (61, Token, string, 0, 32),
     (284, NoResponse, uint, 0, 1),
 ];
+


### PR DESCRIPTION
- add set_option and with_option methods to Client
- add Token option to options enum

Also formatting because fork origin never ran a formatter on it